### PR TITLE
Add Cake.RSyncCore to blacklist

### DIFF
--- a/Source/Cake.AddinDiscoverer/exclusionlist.json
+++ b/Source/Cake.AddinDiscoverer/exclusionlist.json
@@ -34,6 +34,7 @@
     "Cake.PackageType.Module", // This is a proof-of-concept. Not intended to be analyzed and listed on the Cake web site.
     "Cake.PackageType.Recipe", // This is a proof-of-concept. Not intended to be analyzed and listed on the Cake web site.
     "Cake.ReportPortal",
+    "Cake.RSyncCore", // This is a clone of Cake.RSync
     "Cake.Scripting.Abstractions",
     "Cake.Scripting.Transport",
     "Cake.SendMail", // This is a clone of Cake.Email


### PR DESCRIPTION
Adds Cake.RSyncCore, which is a fork of Cake.RSync to blacklist.